### PR TITLE
Adjust methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/LIT-Protocol/lit-bls-wasm"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-blsful = "2"
+blsful = {  version = "2", default-features = false, features = ["rust"] }
 console_error_panic_hook = "0.1"
 base64_light = "0.1"
 getrandom = { version = "0.2", features = ["js"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use base64_light::{base64_decode, base64_encode_bytes};
-use blsful::inner_types::{G1Projective, G2Projective};
+use blsful::inner_types::{G1Projective, G2Projective, GroupEncoding};
 use blsful::{
     Bls12381G1Impl, Bls12381G2Impl, BlsSignatureImpl, PublicKey, Signature, SignatureSchemes,
     SignatureShare, TimeCryptCiphertext,
@@ -140,9 +140,9 @@ pub fn combine_signature_shares(shares: JsValue) -> Result<String, String> {
 
     match shares[0].len() {
         SIGNATURE_G1_SHARE_HEX_LENGTH => combine_signature_shares_inner::<Bls12381G1Impl>(&shares)
-            .map(|s| hex::encode(s.as_raw_value().to_compressed())),
+            .map(|s| hex::encode(s.as_raw_value().to_bytes())),
         SIGNATURE_G2_SHARE_HEX_LENGTH => combine_signature_shares_inner::<Bls12381G2Impl>(&shares)
-            .map(|s| hex::encode(s.as_raw_value().to_compressed())),
+            .map(|s| hex::encode(s.as_raw_value().to_bytes())),
         _ => Err("Invalid shares".to_string()),
     }
 }


### PR DESCRIPTION
This uses the more reliable to_bytes method which fixes an issue when compiling with blsful features="rust".

Also I have updated blsful dependencies to fix an issue when compiling to wasm. This includes the blstrs_plus and bls12_381_plus crates.