### PR TITLE
Fix cyclic dependency involving wasm-bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_bare = "0.5"
 serde-wasm-bindgen = "0.5"
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+wasm-bindgen = "0.2"
 
 [profile.release]
 debug = false


### PR DESCRIPTION
This PR fixes a dependency issue when updating Deno in our main repo and is required to unblock the update.

```
error: cyclic package dependency: package `getrandom v0.2.12` depends on itself. Cycle:
package `getrandom v0.2.12`
    ... which satisfies dependency `getrandom = "^0.2.7"` (locked to 0.2.12) of package `ahash v0.8.11`
    ... which satisfies dependency `ahash = "^0.8.6"` (locked to 0.8.11) of package `hashbrown v0.14.3`
    ... which satisfies dependency `hashbrown = "^0.14.1"` (locked to 0.14.3) of package `indexmap v2.2.6`
    ... which satisfies dependency `indexmap = "^2.2.1"` (locked to 2.2.6) of package `serde_json v1.0.115`
    ... which satisfies dependency `serde_json = "^1.0"` (locked to 1.0.115) of package `wasm-bindgen v0.2.92`
    ... which satisfies dependency `wasm-bindgen = "^0.2.92"` (locked to 0.2.92) of package `js-sys v0.3.69`
    ... which satisfies dependency `js-sys = "^0.3"` (locked to 0.3.69) of package `getrandom v0.2.12`
    ... which satisfies dependency `getrandom = "^0.2"` (locked to 0.2.12) of package `rand_core v0.6.4`
    ... which satisfies dependency `rand_core = "^0.6"` (locked to 0.6.4) of package `crypto-common v0.1.6`
    ... which satisfies dependency `crypto-common = "^0.1.4"` (locked to 0.1.6) of package `aead v0.5.2`
```

See https://github.com/tkaitchuck/aHash/issues/95 for more info.